### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,6 +457,8 @@ class Peer {
     _setIP(request) {
         if (request.headers['cf-connecting-ip']) {
             this.ip = request.headers['cf-connecting-ip'].split(/\s*,\s*/)[0];
+        } else if (request.headers['x-real-ip']) {
+            this.ip = request.headers['x-real-ip'].split(/\s*,\s*/)[0];
         } else if (request.headers['x-forwarded-for']) {
             this.ip = request.headers['x-forwarded-for'].split(/\s*,\s*/)[0];
         } else {


### PR DESCRIPTION
Traefik reports with X-Forwarded-For header the IP address of the container not the client IP address, 
all clients are mutually visible
The client IP address is in the X-Real-Ip header, adding this test to the function:  _setIP(request) 
before the X-Forwarded-For test.
